### PR TITLE
Fixed the issue with the command file button

### DIFF
--- a/scripts/drawables.js
+++ b/scripts/drawables.js
@@ -294,7 +294,7 @@ function generatePlainText() {
   
   var useDirectiveIcon = document.getElementById("usedirectivesicon").checked;
   obj.parameters.inventoryIcon = useDirectiveIcon ? obj.parameters.image
-    : invIcons.hasOwnProperty(selectedInstrument) ? invIcons[selectedInstrument] : (selectedInstrument + "icon.png");
+    : Object.prototype.hasOwnProperty.call(invIcons,selectedInstrument) ? invIcons[selectedInstrument] : (selectedInstrument + "icon.png");
   
   obj.parameters.largeImage = obj.parameters.inventoryIcon + "?scalenearest=2";
 


### PR DESCRIPTION
Just had to replace jquery's `hasOwnProperty` with `Object.prototype.hasOwnProperty.call(obj, key)` to avoid errors when `obj.parameters` is undefined.